### PR TITLE
feat: Add Dockerfile and GitHub Actions workflow for GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,55 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Required to push to GHCR
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha,prefix=,format=long
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use php:apache as the base image
+FROM php:apache
+
+# Install sqlite3 and pdo_sqlite PHP extensions
+RUN docker-php-ext-install pdo_sqlite sqlite3
+
+# Set the working directory
+WORKDIR /var/www/html
+
+# Copy the server directory into the image's document root
+COPY server/ /var/www/html/
+
+# Create a data subdirectory
+RUN mkdir /var/www/html/data
+
+# Set permissions for the data directory
+RUN chown www-data:www-data /var/www/html/data
+RUN chmod 755 /var/www/html/data
+
+# Expose port 80
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -49,13 +49,31 @@ After that first account, account creation is disabled by default.
 
 If you want to allow more accounts, you'll have to configure the server (see "Configuration" below).
 
-### Docker
+## Docker
 
-There is an unofficial [Docker image available](https://github.com/ganeshlab/opodsync). Please report any Docker issue there.
+A Docker image for oPodSync is automatically built and pushed to the GitHub Container Registry (GHCR) on every push to the `main` branch.
 
-If this image stops being maintained, see [Docker Hub](https://hub.docker.com/search?q=opodsync) to find other community distribution for Docker.
+**Image Location:** `ghcr.io/${{ github.repository }}:latest` (or replace `${{ github.repository }}` with the actual repository name, e.g., `ghcr.io/kd2org/opodsync:latest`)
 
-**Please don't report Docker issues here, this repository is only for software development.**
+### Running the container
+
+To run the container, you need to map a volume for persistent data storage. The application stores its SQLite database and other data in `/var/www/html/data` inside the container.
+
+Example:
+
+```bash
+# Create a local directory for persistent data
+mkdir my-opodsync-data
+
+# Run the container
+docker run -d -p 8080:80 \
+    -v $(pwd)/my-opodsync-data:/var/www/html/data \
+    ghcr.io/kd2org/opodsync:latest
+```
+
+Then, access the application at `http://localhost:8080`.
+
+This Docker image and the accompanying GitHub Actions workflow are designed to be repository-agnostic. If you fork this project, the Action will build and push the image to your fork's GHCR automatically without requiring any changes to the workflow files.
 
 ### Configuration
 


### PR DESCRIPTION
This commit introduces a Dockerfile to containerize your oPodSync application and a GitHub Actions workflow to automatically build and publish the image to the GitHub Container Registry (GHCR).

Key changes:
- Added `Dockerfile` using `php:apache` base image, installs necessary PHP extensions (sqlite3, pdo_sqlite), and configures the application.
- Added `.github/workflows/docker-build.yml` which triggers on pushes to main and workflow_dispatch. It builds the Docker image and pushes it to `ghcr.io/<owner>/opodsync` with tags for SHA, branch, and latest.
- Updated `README.md` under the "Docker" section to reflect the new official image, providing instructions on how to pull and run it from GHCR, including volume mapping for persistent data. The workflow is repository-agnostic and works for forks.