### PR TITLE
fix: Install libsqlite3-dev in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,24 @@
 # Use php:apache as the base image
 FROM php:apache
 
+# Install system dependencies for PHP extensions
+RUN apt-get update && apt-get install -y \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install sqlite3 and pdo_sqlite PHP extensions
 RUN docker-php-ext-install pdo_sqlite sqlite3
 
 # Set the working directory
 WORKDIR /var/www/html
 
-# Copy the server directory into the image's document root
+# Copy the server directory contents into the image's document root
 COPY server/ /var/www/html/
 
-# Create a data subdirectory
-RUN mkdir /var/www/html/data
-
-# Set permissions for the data directory
-RUN chown www-data:www-data /var/www/html/data
-RUN chmod 755 /var/www/html/data
+# Create a data subdirectory inside the application directory
+RUN mkdir -p /var/www/html/data && chown www-data:www-data /var/www/html/data && chmod 755 /var/www/html/data
 
 # Expose port 80
 EXPOSE 80
+
+# The default CMD from php:apache (apache2-foreground) will be used


### PR DESCRIPTION
This commit fixes the Docker image build failure by adding `libsqlite3-dev` as a system dependency. The `sqlite3` PHP extension requires this package for successful compilation.

The `apt-get update` and `apt-get install -y libsqlite3-dev` commands are now run before `docker-php-ext-install pdo_sqlite sqlite3`.